### PR TITLE
Normalize enum values from discovery documents

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -468,6 +468,34 @@ class Utilities(unittest.TestCase):
         self.assertEqual(parameters.param_types, param_types)
         self.assertEqual(parameters.enum_params, {})
 
+    def test_ResourceMethodParameters_enum_values_dict(self):
+        method_desc = {
+            "id": "drive.items.conflictBehavior",
+            "path": "drive/items",
+            "httpMethod": "POST",
+            "parameters": {
+                "@microsoft.graph.conflictBehavior": {
+                    "type": "string",
+                    "location": "query",
+                    "enum": [
+                        {"name": "fail", "value": "fail"},
+                        {"name": "rename", "value": "rename"},
+                    ],
+                }
+            },
+        }
+
+        parameters = ResourceMethodParameters(method_desc)
+
+        expected_values = ["fail", "rename"]
+        enum_key = "x_microsoft_graph_conflictBehavior"
+        self.assertIn(enum_key, parameters.enum_params)
+        self.assertEqual(parameters.enum_params[enum_key], expected_values)
+        self.assertEqual(
+            method_desc["parameters"]["@microsoft.graph.conflictBehavior"]["enum"],
+            expected_values,
+        )
+
 
 class Discovery(unittest.TestCase):
     def test_discovery_http_is_closed(self):


### PR DESCRIPTION
## Summary
- normalize enum definitions that supply dictionaries so their underlying values can be validated
- update method descriptions to expose the normalized enum strings
- add a unit test covering conflictBehavior-style parameters

## Testing
- pytest tests/test_discovery.py::Utilities::test_ResourceMethodParameters_enum_values_dict


------
https://chatgpt.com/codex/tasks/task_e_68cafb2f7ccc8322aea4e63d1066d089